### PR TITLE
relax dependency on net-ssh

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,7 @@ Jeweler::Tasks.new do |gemspec|
   gemspec.homepage = "http://github.com/rightscale/rest_connection"
   gemspec.authors = ["Jeremy Deininger", "Timothy Rodriguez"]
   gemspec.add_dependency('activesupport', "=2.3.10")
-  gemspec.add_dependency('net-ssh', "=2.1.4")
+  gemspec.add_dependency('net-ssh', ">=2.1.4")
   gemspec.add_dependency('json')
   gemspec.add_dependency('highline')
   gemspec.add_dependency('rest-client')


### PR DESCRIPTION
Hard-coding the requirement on 2.1.4 of net-ssh causes the gem to fail in an environment with 2.2.1 instead, though as far as I can tell there isn't a specific reason that it needs to be constrained to the older version