### PR TITLE
ability to specify a log file via settings

### DIFF
--- a/lib/rest_connection.rb
+++ b/lib/rest_connection.rb
@@ -253,7 +253,11 @@ module RestConnection
     def logger(message)
       init_message = "Initializing Logging using "
       if @@logger.nil?
-        if ENV['REST_CONNECTION_LOG']
+        if @settings[:log]
+          # pass a filename, or an object that responds to write/close methods
+          @@logger = Logger.new(@settings[:log])
+          init_message += @settings[:log].to_s
+        elsif ENV['REST_CONNECTION_LOG']
           @@logger = Logger.new(ENV['REST_CONNECTION_LOG'])
           init_message += ENV['REST_CONNECTION_LOG']
         else


### PR DESCRIPTION
This can be a filename specified in the config.yaml file, but can also be an
object passed in to the initialization method that responds to the
appropriate logging methods