### PR TITLE
acu91860 - Fix activesupport incompatibility (w-5735)

### DIFF
--- a/lib/rest_connection/patches.rb
+++ b/lib/rest_connection/patches.rb
@@ -111,6 +111,7 @@ class Array
     end
   end
 
+  alias :old_multiply :*
   def *(second)
     if second.is_a?(Integer)
       ret = []
@@ -121,7 +122,7 @@ class Array
       each { |x| second.each { |y| ret << [x,y].flatten } }
       return ret
     else
-      raise TypeError.new("can't convert #{second.class} into Integer")
+      old_multiply(second)
     end
   end
 


### PR DESCRIPTION
This fixes in incompatibility with some combination of activesupport/right_agent and rest_connection where if rest_connection is loaded last it overwrite the Array \* operator and causes a conflict
