### PR TITLE
acu120254 Limit activesupport version

### DIFF
--- a/rest_connection.gemspec
+++ b/rest_connection.gemspec
@@ -18,7 +18,6 @@ It currently has support for RightScale API 1.0 and 1.5.
   s.test_files = `git ls-files spec config`.split(' ')
   s.rubygems_version = '1.8.24'
 
-  s.add_runtime_dependency 'activesupport'
   s.add_runtime_dependency 'net-ssh'
   s.add_runtime_dependency 'json'
   s.add_runtime_dependency 'highline'
@@ -29,11 +28,14 @@ It currently has support for RightScale API 1.0 and 1.5.
   s.add_development_dependency 'rspec',        '1.3.0'
   # If we're using Ruby 1.9.x
   if RUBY_VERSION =~ /1.9.*/
+    s.add_runtime_dependency 'activesupport'
     s.add_runtime_dependency 'nokogiri'
     s.add_development_dependency 'ruby-debug19'
   elsif RUBY_VERSION =~ /1.8.*/
-    # Ruby 1.8.x requires limited nokogiri version
+    # Ruby 1.8.x needs limited nokogiri version
     s.add_runtime_dependency 'nokogiri', "<1.6.0"
+    # Ruby 1.8.x needs limited activesupport version
+    s.add_runtime_dependency 'activesupport', "<4.0.0"
     s.add_development_dependency 'ruby-debug'
   else
     raise "Ruby version '#{RUBY_VERSION}' is not currently supported."


### PR DESCRIPTION
Note: activesupport is used for the inflector
