### PR TITLE
White 14 06 acu122897 fix ssh key path

### DIFF
--- a/lib/rest_connection/ssh_hax.rb
+++ b/lib/rest_connection/ssh_hax.rb
@@ -40,7 +40,7 @@ module SshHax
       ssh_keys = connection_keys
     else
       # If no key(s) provided, assume a standard monkey configuration which uses '/root/.ssh/api_user_key'.
-      api_user_key_ssh_key_file_name = '/root/.ssh/api_user_key'
+      api_user_key_ssh_key_file_name = File.expand_path('~/.ssh/api_user_key')
       raise "FATAL ERROR: #{api_user_key_ssh_key_file_name} does not exist." if !File.exist?(api_user_key_ssh_key_file_name)
       ssh_keys = [api_user_key_ssh_key_file_name]
     end


### PR DESCRIPTION
- Jon had apparently "fixed" the path to the standard monkey SSH key by hard coding it to that of the root user. This undoes that fix and expands the user directory for the key.